### PR TITLE
Redfishtool 0.9.2 fixes so that raw subcmd doesnt access root 1st, and other optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 
 # Change Log
 
+## [0.9.2] - 2016-12-05
+- modified "raw" subcommand so that it does not execute /redfish or /redfish/v1 before executing the raw api
+- changed default behavior to NOT always send a /redfish query and verify that the remote service supports the specified redfishProtocol before executing the API
+- added a new -C option to invoke the "Check remote RedfishProtocol Version" before executing function.  If -R "Latest" is set by the user, then the -C flat is auto-set since "Latest" means use the latest mutually supported version
+- changed the default -R <redfishVersion> from "Latest" to "v1" since Latest will require the check and add an additional Get /Redfish query
+- added elapsed execution time output if -ss or -sss is specified
+- updated usage for the above changes
+
 ## [0.9.1] - 2016-09-06
 - Initial Public Release -- supports most Redfish 1.0 features

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ While other generic http clients such as Linux curl can send and receive Redfish
                                            -vvvvv(max dbg)
                                            *** use -vvv to see all of the requests being sent for a command
        -s,  --status                    -- status level, can repeat up to 5 times for more status output
-                                          -s(http_status), -ss(+r.url), 
-                                          -sss(+requestHdrs,data,authType, +respStatus_code, AuthToken/sessId/sessUri)
+                                          -s(http_status), 
+                                          -ss(+r.url, +r.elapsed executionTime ),
+                                          -sss(+requestHdrs,data,authType, +respStatus_code, +elapsed exec time, 
+                                               AuthToken/sessId/sessUri)
                                           -ssss(+response headers for debug), -sssss(+response data for debug)
 ###### Options used by "raw" subcommand:
        -d <data>   --data=<data>        -- the http request "data" to send on PATCH,POST,or PUT requests
@@ -95,8 +97,12 @@ While other generic http clients such as Linux curl can send and receive Redfish
        -A <Authn>,   --Auth <Authn>      -- Authentication type to use:  Authn={None|Basic|Session}  Default is Basic
        -S <Secure>,  --Secure=<Secure>   -- When to use https: (Note: doesn't stop rhost from redirect http to https)
                                  <Secure>={Always | IfSendingCredentials | IfLoginOrAuthenticatedApi(default) | Never }
-       -V <ver>,  --RedfishVersion=<ver> -- The Major Redfish Protocol version to use: ver={1, <n>, Latest(default)}
-       -H <hdrs>, --Headers=<hdrs>       -- Specify the request header list--overrides defaults. Format "{ A:B, C:D...}"
+       -R <ver>,  --RedfishVersion=<ver> -- The Major Redfish Protocol version to use: ver={v1(default), v<n>, Latest }
+       -C         --CheckRedfishVersion  -- tells Redfishtool to execute GET /redfish to verify that the rhost supports
+                                            the specified redfish protocol version before executing the sub-command.
+                                            The -C flag is auto-set if the "-R Latest"  or "-W ..." options were selected.
+                                            was specified by the user.
+       -H <hdrs>, --Headers=<hdrs>       -- Specify the request header list--overrides defaults. Format "{ A:B, C:D...}
        -D <flag>,  --Debug=<flag>        -- Flag for dev debug. <flag> is a 32-bit uint: 0x<hex> or <dec> format
     
 ### Subcommands:
@@ -110,7 +116,7 @@ While other generic http clients such as Linux curl can send and receive Redfish
      SessionService           -- operations on SessionService including Session login/logout
      odata                    -- get the Odata Service Documant: GET ^/redfish/v1/odata
      metadata                 -- get the CSDL metadata document: GET ^/redfish/v1/$metadata
-     raw                      -- execute raw redfish http methods and URIs
+     raw                      -- execute raw redfish http methods and URIs (-C option will be ignored)
      hello                    -- redfishtool hello world subcommand for dev testing
    For Subcommand usage, including subcommand Operations and OtherArgs, execute:
    

--- a/redfishtool/ServiceRoot.py
+++ b/redfishtool/ServiceRoot.py
@@ -3,7 +3,7 @@
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfishtool/LICENSE.md
 
 # redfishtool: ServiceRoot.py
-# v0.9.1
+# v0.9.2
 # contains serviceRoot related subCommands and access functions
 # Class RfServiceRoot
 #  - getServiceRoot   GET /redfish/v1
@@ -36,7 +36,7 @@ class RfServiceRoot:
         if cmdTop is True:  prop=rft.prop
 
         # get root service.  if -P prop, showproperty
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rft.rootPath,prop=prop)
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rft.rootPath,prop=prop)
 
         #save the rootService response.  The transport may need it later to get link to session and login
         rft.rootResponseDict=d
@@ -59,8 +59,8 @@ class RfServiceRoot:
 
         #calculate relative path = rootPath / odata
         rpath=urljoin(rft.rootPath, "odata")
-
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rpath)
+        
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rpath)
         if(rc==0 ):
             rft.printVerbose(1," Odata Service Document:",skip1=True, printV12=cmdTop)
         return(rc,r,j,d)
@@ -85,7 +85,7 @@ class RfServiceRoot:
         hdrs = {"Accept": "application/xml", "OData-Version": "4.0" }
 
 
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rpath, jsonData=False, headersInput=hdrs )
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rpath, jsonData=False, headersInput=hdrs )
         if(rc==0):
             rft.printVerbose(1," Odata Metadata Document:",skip1=True,printV12=cmdTop)
         return(rc,r,j,d)

--- a/redfishtool/raw.py
+++ b/redfishtool/raw.py
@@ -29,8 +29,8 @@ import json
 import getopt
 import re
 import sys
-from    .ServiceRoot import RfServiceRoot
-from   urllib.parse import urljoin
+#from    .ServiceRoot import RfServiceRoot
+from   urllib.parse import urljoin, urlparse, urlunparse
 
 class RfRawMain():
     def __init__(self):
@@ -183,20 +183,18 @@ class RfRawOperations():
     def httpGet(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in raw".format(rft.subcommand,sc.operation))
         
-        # 1st get serviceRoot
-        svcRoot=RfServiceRoot()
-        rc,r,j,d = svcRoot.getServiceRoot(rft)
-        if( rc != 0 ):
-            rft.printErr("raw: Error getting service root, aborting")
-            return(rc,r,False,None)
-        rootUrl=r.url
-
         # we verified that we had two args in RawMain(), so we can just read the <uri> arg here
         path=sc.args[1]
         method="GET"
         rft.printVerbose(4,"raw: GET: method:{} path:{}".format(method,path))
 
         apiType=self.getApiType(rft,path)   # UNAUTHENTICATED API or Authenticated API
+
+        # calculate rootUrl--with correct scheme, root path, and rhost IP (w/o querying rhost)
+        scheme=rft.getApiScheme(apiType)
+        scheme_tuple=[scheme, rft.rhost, "/redfish", "","",""]
+        rootUrl=urlunparse(scheme_tuple)  # so rootUrl="http[s]://<rhost>[:<port>]/redfish"
+        
         if cmdTop is True:   prop=rft.prop
         jsonData=True
         if (path=="/redfish/v1/$metadata"): jsonData=False
@@ -211,21 +209,18 @@ class RfRawOperations():
     def httpHead(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in raw".format(rft.subcommand,sc.operation))
         
-        # 1st get serviceRoot
-        svcRoot=RfServiceRoot()
-        rc,r,j,d = svcRoot.getServiceRoot(rft)
-        if( rc != 0 ):
-            rft.printErr("raw: Error getting service root, aborting")
-            return(rc,r,False,None)
-        rootUrl=r.url
-
         # we verified that we had two args in RawMain(), so we can just read the <uri> arg here
         path=sc.args[1]
         method="HEAD"
         rft.printVerbose(4,"raw: HEAD: method:{} path:{}".format(method,path))
 
         apiType=self.getApiType(rft,path)   # UNAUTHENTICATED API or Authenticated API
-
+        
+        # calculate rootUrl--with correct scheme, root path, and rhost IP (w/o querying rhost)
+        scheme=rft.getApiScheme(apiType)
+        scheme_tuple=[scheme, rft.rhost, "/redfish", "","",""]
+        rootUrl=urlunparse(scheme_tuple)  # so rootUrl="http[s]://<rhost>[:<port>]/redfish"
+        
         rc,r,j,d=rft.rftSendRecvRequest(apiType, method, rootUrl, relPath=path)
         if(rc==0):
             rft.printVerbose(1," raw HEAD:",skip1=True, printV12=cmdTop)  
@@ -249,13 +244,6 @@ class RfRawOperations():
             return(5,None,False,None)
         ##print("patchData: {}".format(patchData))
 
-        # 1st get serviceRoot
-        svcRoot=RfServiceRoot()
-        rc,r,j,d = svcRoot.getServiceRoot(rft)
-        if( rc != 0 ):
-            rft.printErr("raw: Error getting service root, aborting")
-            return(rc,r,False,None)
-        rootUrl=r.url
 
         # we verified that we had two args in RawMain(), so we can just read the <uri> arg here
         path=sc.args[1]
@@ -263,6 +251,11 @@ class RfRawOperations():
         rft.printVerbose(4,"raw: PATCH: method:{} path:{}".format(method,path))
 
         apiType=self.getApiType(rft,path)   # UNAUTHENTICATED API or Authenticated API
+
+        # calculate rootUrl--with correct scheme, root path, and rhost IP (w/o querying rhost)
+        scheme=rft.getApiScheme(apiType)
+        scheme_tuple=[scheme, rft.rhost, "/redfish", "","",""]
+        rootUrl=urlunparse(scheme_tuple)  # so rootUrl="http[s]://<rhost>[:<port>]/redfish"
 
         #read the resource--the generic patch command needs it to get the etag
         rc,r,j,d=rft.rftSendRecvRequest(apiType, "GET", rootUrl, relPath=path)
@@ -289,20 +282,17 @@ class RfRawOperations():
             return(5,None,False,None)
         ##print("postData: {}".format(postData))
 
-        # 1st get serviceRoot
-        svcRoot=RfServiceRoot()
-        rc,r,j,d = svcRoot.getServiceRoot(rft)
-        if( rc != 0 ):
-            rft.printErr("raw: Error getting service root, aborting")
-            return(rc,r,False,None)
-        rootUrl=r.url
-
         # we verified that we had two args in RawMain(), so we can just read the <uri> arg here
         path=sc.args[1]
         method="POST"
         rft.printVerbose(4,"raw: POST: method:{} path:{}".format(method,path))
 
         apiType=self.getApiType(rft,path)   # UNAUTHENTICATED API or Authenticated API
+
+        # calculate rootUrl--with correct scheme, root path, and rhost IP (w/o querying rhost)
+        scheme=rft.getApiScheme(apiType)
+        scheme_tuple=[scheme, rft.rhost, "/redfish", "","",""]
+        rootUrl=urlunparse(scheme_tuple)  # so rootUrl="http[s]://<rhost>[:<port>]/redfish"
 
         #output the post data in json to send over the network   
         reqPostData=json.dumps(postData)
@@ -322,14 +312,6 @@ class RfRawOperations():
     def httpDelete(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in raw".format(rft.subcommand,sc.operation))
 
-        # 1st get serviceRoot
-        svcRoot=RfServiceRoot()
-        rc,r,j,d = svcRoot.getServiceRoot(rft)
-        if( rc != 0 ):
-            rft.printErr("raw: Error getting service root, aborting")
-            return(rc,r,False,None)
-        rootUrl=r.url
-
         # we verified that we had two args in RawMain(), so we can just read the <uri> arg here
         path=sc.args[1]
         method="DELETE"
@@ -337,6 +319,10 @@ class RfRawOperations():
 
         apiType=self.getApiType(rft,path)   # UNAUTHENTICATED API or Authenticated API
 
+        # calculate rootUrl--with correct scheme, root path, and rhost IP (w/o querying rhost)
+        scheme=rft.getApiScheme(apiType)
+        scheme_tuple=[scheme, rft.rhost, "/redfish", "","",""]
+        rootUrl=urlunparse(scheme_tuple)  # so rootUrl="http[s]://<rhost>[:<port>]/redfish"
 
         #send DELETE to the resource path specified
         rc,r,j,d=rft.rftSendRecvRequest(apiType, method, rootUrl, relPath=path)
@@ -362,7 +348,8 @@ class RfRawOperations():
 TODO:
 1. need to handle case where no patch or post data (no -d)
 2. add raw PUT
-
+CHANGES:
+0.9.2:  no longer call /redfish and /redfish/v1 before executing the raw api
 '''
 
     


### PR DESCRIPTION
See Change Log
raw subcommad wont do a GET /redfish and Get /redfish/v1 before executing the uri.
By default other subcommands will not do a Get /redfish and verify the protocol is supported.
-C option was added to check the protocol version if desired, but by default it does  not.
also -ss and -sss prints out elapsed execution time