### PR TITLE
Fix for Issue 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [1.0.1] - 2017-6-15
+- created a script called `redfishtool` to be installed via `pip install redfishtool`
+
 ## [1.0.0] - 2017-6-1
 - added AccountService setusername operation to modify the UserName property in an existing account
 

--- a/scripts/redfishtool
+++ b/scripts/redfishtool
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# Copyright Notice:
+# Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfishtool/LICENSE.md
+
+# redfishtool:  redfishtool.py
+#
+# contents:
+#  -CLI wrapper:  calls main() routine in ./redfishtool  package
+#
+#  Note: structure supports a future lib interface to the routines
+#        where the libWrapper is the interface
+#
+from redfishtool import main
+import sys
+
+if __name__ == "__main__":
+    main(sys.argv)
+
+
+

--- a/scripts/redfishtool
+++ b/scripts/redfishtool
@@ -3,10 +3,10 @@
 # Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfishtool/LICENSE.md
 
-# redfishtool:  redfishtool.py
+# redfishtool:  scripts/redfishtool
 #
 # contents:
-#  -CLI wrapper:  calls main() routine in ./redfishtool  package
+#  -CLI wrapper:  calls main() routine in redfishtool  package
 #
 #  Note: structure supports a future lib interface to the routines
 #        where the libWrapper is the interface
@@ -16,6 +16,3 @@ import sys
 
 if __name__ == "__main__":
     main(sys.argv)
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='redfishtool',
-      version='1.0.0',
+      version='1.0.1',
       description='Redfishtool package and command-line client',
       author='DMTF, https://www.dmtf.org/standards/feedback',
       license='BSD 3-clause "New" or "Revised License"',
@@ -14,8 +14,8 @@ setup(name='redfishtool',
       ],
       keywords='Redfish',
       url='https://github.com/DMTF/Redfishtool',
-      download_url='https://github.com/DMTF/Redfishtool/archive/1.0.0.tar.gz',
+      download_url='https://github.com/DMTF/Redfishtool/archive/1.0.1.tar.gz',
       packages=['redfishtool'],
-      scripts=['redfishtool.py'],
+      scripts=['scripts/redfishtool'],
       install_requires=['requests']
       )


### PR DESCRIPTION
Created `redfishtool` script to be installed via `pip install redfishtool`. This is a copy of the existing `redfishtool.py` wrapper without the `.py` extension. This avoids the name conflict between the `redfishtool.py` module and the `redfishtool` package.

Updated setup.py to reference version 1.0.1 so this new version can be uploaded to PyPI.

Fixes #13

[Redfishtool Issue 13 log.pdf](https://github.com/DMTF/Redfishtool/files/1078656/Redfishtool.Issue.13.log.pdf)
