### PR TITLE
Add @Redfish.ActionInfo support

### DIFF
--- a/redfishtool/Managers.py
+++ b/redfishtool/Managers.py
@@ -329,13 +329,19 @@ class RfManagersOperations():
             if( "ResetType@Redfish.AllowableValues" in resetProps ):
                 supportedResetTypes=resetProps["ResetType@Redfish.AllowableValues"]
                 if not resetType in supportedResetTypes:
-                    rft.printErr("Error, the resetType specified is not supported by the remote service")
+                    rft.printErr("Error, the resetType specified is not supported by the remote service (via @Redfish.AllowableValues)")
+                    return(8,None,False,None)
+            elif "@Redfish.ActionInfo" in resetProps:
+                action_info_path = resetProps["@Redfish.ActionInfo"]
+                supportedResetTypes = rft.getActionInfoAllowableValues(rft, r, action_info_path, "ResetType")
+                if resetType not in supportedResetTypes:
+                    rft.printErr("Error, the resetType specified is not supported by the remote service (via @Redfish.ActionInfo)")
                     return(8,None,False,None)
             else: # rhost didn't return any AllowableValues.  So this tool will not try to set it!
-                rft.printErr("Error, the remote service doesnt have a resetType allowableValues prop")
+                rft.printErr("Error, the remote service does not have a ResetType@Redfish.AllowableValues or @Redfish.ActionInfo prop")
                 return(8,None,False,None)
         else:
-            rft.printErr("Error, the remote service doesnt have an Actions: ComputerSystem.Reset property")
+            rft.printErr("Error, the remote service does not have an Actions: Manager.Reset property")
             return(8,None,False,None)
         
         # now get the target URI from the remote host

--- a/redfishtool/Managers.py
+++ b/redfishtool/Managers.py
@@ -308,7 +308,7 @@ class RfManagersOperations():
         
         # get the resetType from args
         validResetTypes=["On","ForceOff","GracefulShutdown","ForceRestart","Nmi","GracefulRestart",
-                                    "ForceOn","PushPowerButton"]
+                                    "ForceOn","PushPowerButton","PowerCycle"]
         if(len(sc.args) < 2 ):
             rft.printErr("Error, no resetType value specified")
             return(8,None,False,None)
@@ -334,12 +334,11 @@ class RfManagersOperations():
             elif "@Redfish.ActionInfo" in resetProps:
                 action_info_path = resetProps["@Redfish.ActionInfo"]
                 supportedResetTypes = rft.getActionInfoAllowableValues(rft, r, action_info_path, "ResetType")
-                if resetType not in supportedResetTypes:
+                if supportedResetTypes is not None and resetType not in supportedResetTypes:
                     rft.printErr("Error, the resetType specified is not supported by the remote service (via @Redfish.ActionInfo)")
                     return(8,None,False,None)
-            else: # rhost didn't return any AllowableValues.  So this tool will not try to set it!
-                rft.printErr("Error, the remote service does not have a ResetType@Redfish.AllowableValues or @Redfish.ActionInfo prop")
-                return(8,None,False,None)
+            else: # rhost didn't return any AllowableValues, but it isn't required, so allow the action
+                rft.printVerbose(2, "The remote service does not have a ResetType@Redfish.AllowableValues or @Redfish.ActionInfo prop")
         else:
             rft.printErr("Error, the remote service does not have an Actions: Manager.Reset property")
             return(8,None,False,None)

--- a/redfishtool/Systems.py
+++ b/redfishtool/Systems.py
@@ -316,7 +316,7 @@ class RfSystemsOperations():
         
         # get the resetType from args
         validResetTypes=["On","ForceOff","GracefulShutdown","ForceRestart","Nmi","GracefulRestart",
-                                    "ForceOn","PushPowerButton"]
+                                    "ForceOn","PushPowerButton","PowerCycle"]
         if(len(sc.args) < 2 ):
             rft.printErr("Error, no resetType value specified")
             return(8,None,False,None)
@@ -342,12 +342,11 @@ class RfSystemsOperations():
             elif "@Redfish.ActionInfo" in resetProps:
                 action_info_path = resetProps["@Redfish.ActionInfo"]
                 supportedResetTypes = rft.getActionInfoAllowableValues(rft, r, action_info_path, "ResetType")
-                if resetType not in supportedResetTypes:
+                if supportedResetTypes is not None and resetType not in supportedResetTypes:
                     rft.printErr("Error, the resetType specified is not supported by the remote service (via @Redfish.ActionInfo)")
                     return(8,None,False,None)
-            else: # rhost didn't return any AllowableValues.  So this tool will not try to set it!
-                rft.printErr("Error, the remote service does not have a ResetType@Redfish.AllowableValues or @Redfish.ActionInfo prop")
-                return(8,None,False,None)
+            else: # rhost didn't return any AllowableValues, but it isn't required, so allow the action
+                rft.printVerbose(2, "The remote service does not have a ResetType@Redfish.AllowableValues or @Redfish.ActionInfo prop")
         else:
             rft.printErr("Error, the remote service does not have an Actions: ComputerSystem.Reset property")
             return(8,None,False,None)
@@ -504,12 +503,11 @@ class RfSystemsOperations():
                 elif "@Redfish.ActionInfo" in d["Boot"]:
                     action_info_path = d["Boot"]["@Redfish.ActionInfo"]
                     rhostSupportedTargets = rft.getActionInfoAllowableValues(rft, r, action_info_path, "BootSourceOverrideTarget")
-                    if targetVal not in rhostSupportedTargets:
+                    if rhostSupportedTargets is not None and targetVal not in rhostSupportedTargets:
                         rft.printErr("Error, the boot target specified is not supported by the remote service (via @Redfish.ActionInfo)")
                         return (8, None, False, None)
-                else: # rhost didn't return any AllowableValues.  So this tool will not try to set it!
-                    rft.printErr("Error, the remote service does not have a BootSourceOverrideTarget@Redfish.AllowableValues or @Redfish.ActionInfo prop")
-                    return(8,None,False,None)
+                else: # rhost didn't return any AllowableValues, but it isn't required, so allow the action
+                    rft.printVerbose(2, "The remote service does not have a BootSourceOverrideTarget@Redfish.AllowableValues or @Redfish.ActionInfo prop")
             else:
                 rft.printErr("Error, the remote service does not have a Boot prop")
                 return (8, None, False, None)

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -1142,7 +1142,7 @@ class RfTransport():
         return(namespace, version, resourceType)
 
     def getActionInfoAllowableValues(self, rft, r, relPath, paramName):
-        allowable_values = list()
+        allowable_values = None
         rc, r, j, d = rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url, relPath=relPath)
         if rc == 0 and j and d is not None:
             if "Parameters" in d and isinstance(d["Parameters"], list):

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -1141,9 +1141,22 @@ class RfTransport():
     
         return(namespace, version, resourceType)
 
+    def getActionInfoAllowableValues(self, rft, r, relPath, paramName):
+        allowable_values = list()
+        rc, r, j, d = rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url, relPath=relPath)
+        if rc == 0 and j and d is not None:
+            if "Parameters" in d and isinstance(d["Parameters"], list):
+                params = d["Parameters"]
+                for param in params:
+                    if "Name" in param and param["Name"] == paramName and "AllowableValues" in param:
+                        allowable_values = param["AllowableValues"]
+                        rft.printVerbose(2, 'getActionInfoAllowableValues: found "AllowableValues" {}'
+                                         .format(allowable_values))
+                        break
+        else:
+            rft.printErr('Error getting AllowableValues from uri {}; rc = {}, response = {}'.format(relPath, rc, r))
+        return allowable_values
 
-
-        
 '''
 TODO:
 1.


### PR DESCRIPTION
Updates:
- added support to use @Redfish.ActionInfo if @Redfish.AllowableValues not available
- updated logic to allow the action if the service does not report the allowable values
- added "PowerCycle" to the list of valid reset types per recent Resource.v1_4_0 schema update


Fixes #23 