### PR TITLE
Add support for --all option to Systems and Chassis commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [1.0.2] - 2017-10-5
+- added support for `--all` option to Systems and Chassis commands that perform update operations
+
 ## [1.0.1] - 2017-6-15
 - created a script called `redfishtool` to be installed via `pip install redfishtool`
 

--- a/README.md
+++ b/README.md
@@ -306,20 +306,35 @@ While other generic http clients such as Linux curl can send and receive Redfish
      # Gets the first system and verify that there is only one system
      redfishtool -r <ip> -u <username> -p <password> Systems -1
 
-     # Patches the json-formated {prop: value...}  data to the object
+     # Patches the json-formated {prop: value...} data to the specified system
      redfishtool -r <ip> -u <username> -p <password> Systems -I <id> patch {A: B,C: D,...}
+
+     # Patches the json-formated {prop: value...} data to all systems
+     redfishtool -r <ip> -u <username> -p <password> Systems --all patch {A: B,C: D,...}
 
      # Resets a system.  <resetType>=the redfish-defined values: On, Off, gracefulOff...
      redfishtool -r <ip> -u <username> -p <password> Systems -I <id> reset <resetType>
 
+     # Resets all systems.  <resetType>=the redfish-defined values: On, Off, gracefulOff...
+     redfishtool -r <ip> -u <username> -p <password> Systems --all reset <resetType>
+
      # Sets the system's asset tag to <assetTag>
      redfishtool -r <ip> -u <username> -p <password> Systems -I <id> setAssetTag <assetTag>
+
+     # Sets all system's asset tags to <assetTag>
+     redfishtool -r <ip> -u <username> -p <password> Systems --all setAssetTag <assetTag>
 
      # Sets the indicator LED.  <state>=redfish defined values: Off, Lit, Blinking
      redfishtool -r <ip> -u <username> -p <password> Systems -I <id> setIndicatorLed <state>
 
+     # Sets the indicator LED on all systems. <state>=redfish defined values: Off, Lit, Blinking
+     redfishtool -r <ip> -u <username> -p <password> Systems --all setIndicatorLed <state>
+
      # Sets Boot Override properties.  <enabledVal>=Disabled|Once|Continuous
      redfishtool -r <ip> -u <username> -p <password> Systems -I <id> setBootOverride <enabledVal> <targetVal>
+
+     # Sets Boot Override properties on all systems.  <enabledVal>=Disabled|Once|Continuous
+     redfishtool -r <ip> -u <username> -p <password> Systems --all setBootOverride <enabledVal> <targetVal>
 
      # Gets the Processor Collection
      redfishtool -r <ip> -u <username> -p <password> Systems -I <Id> Processors
@@ -357,14 +372,23 @@ While other generic http clients such as Linux curl can send and receive Redfish
      # Gets the first Chassis and verify that there is only one system
      redfishtool -r <ip> -u <username> -p <password> Chassis -1
 
-     # Patches the json-formated {prop: value...} data to the object
+     # Patches the json-formated {prop: value...} data to the specified chassis
      redfishtool -r <ip> -u <username> -p <password> Chassis -I <id> patch {A: B,C: D,...}
+
+     # Patches the json-formated {prop: value...} data to all chassis
+     redfishtool -r <ip> -u <username> -p <password> Chassis --all patch {A: B,C: D,...}
 
      # Sets the chassis's asset tag
      redfishtool -r <ip> -u <username> -p <password> Chassis -I <id> setAssetTag <assetTag>
 
+     # Sets all chassis's asset tags
+     redfishtool -r <ip> -u <username> -p <password> Chassis --all setAssetTag <assetTag>
+
      # Sets the indicator LED.  <state>=redfish defined values: Off, Lit, Blinking
      redfishtool -r <ip> -u <username> -p <password> Chassis -I <id> setIndicatorLed <state>
+
+     # Sets the indicator LED on all chassis.  <state>=redfish defined values: Off, Lit, Blinking
+     redfishtool -r <ip> -u <username> -p <password> Chassis --all setIndicatorLed <state>
 
      # Gets the full chassis Power resource
      redfishtool -r <ip> -u <username> -p <password> Chassis -I <Id> Power
@@ -377,6 +401,9 @@ While other generic http clients such as Linux curl can send and receive Redfish
 
      # Sets the power limit
      redfishtool -r <ip> -u <username> -p <password> Chassis -L<Url> setPowerLimit [-i<indx>] <limit> [<exception> [<correctionTime>]]
+
+     # Sets the power limit on all chassis
+     redfishtool -r <ip> -u <username> -p <password> Chassis --all setPowerLimit [-i<indx>] <limit> [<exception> [<correctionTime>]]
 
 ### Managers subcommand Examples
 

--- a/redfishtool/Systems.py
+++ b/redfishtool/Systems.py
@@ -154,7 +154,8 @@ class RfSystemsMain():
         rft.printVerbose(5,"Systems: operation={}, args={}".format(self.operation,self.args))
                 
         # check if the command requires a collection member target -I|-M|-L|-1|-F eg sysIdoptn
-        nonIdCommands=["collection", "list", "examples", "hello", "reset"]
+        nonIdCommands=["collection", "list", "examples", "hello", "reset", "patch", "setAssetTag",
+                       "setIndicatorLed", "setBootOverride"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
             rft.printErr("Systems: Syntax error: [-I|-M|-L|-F|-1] required for action that targets a specific system instance")
             return(0,None,False,None)
@@ -273,7 +274,7 @@ class RfSystemsOperations():
         return(rc,r,j,d)
 
     
-    def patch(self,sc,op,rft,cmdTop=False, prop=None, patchData=None, r=None):
+    def patch_single(self,sc,op,rft,cmdTop=False, prop=None, patchData=None, r=None):
         rft.printVerbose(4,"{}:{}: in operation".format(rft.subcommand,sc.operation))
         # verify we have got an argument which is the patch structure
         # its in form '{ "AssetTag": <val>, "IndicatorLed": <val> }'
@@ -305,6 +306,10 @@ class RfSystemsOperations():
 
         if(rc==0):   rft.printVerbose(1," Systems Patch:",skip1=True, printV12=cmdTop)
         return(rc,r,j,d)
+
+
+    def patch(self, sc, op, rft, cmdTop=False, prop=None):
+        return op.iterate_op(op.patch_single, sc, op, rft, cmdTop=cmdTop, prop=prop)
 
 
     def reset_single(self,sc,op,rft,cmdTop=False, prop=None):
@@ -419,7 +424,7 @@ class RfSystemsOperations():
             return run_single(sc, op, rft, cmdTop=cmdTop, prop=prop)
 
 
-    def setAssetTag(self,sc,op,rft,cmdTop=False, prop=None):
+    def setAssetTag_single(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in operation".format(rft.subcommand,sc.operation))
 
         propName="AssetTag"
@@ -448,7 +453,11 @@ class RfSystemsOperations():
         else: return(rc,r,False,None)
 
 
-    def setIndicatorLed(self,sc,op,rft,cmdTop=False, prop=None):
+    def setAssetTag(self, sc, op, rft, cmdTop=False, prop=None):
+        return op.iterate_op(op.setAssetTag_single, sc, op, rft, cmdTop=cmdTop, prop=prop)
+
+
+    def setIndicatorLed_single(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in operation".format(rft.subcommand,sc.operation))
 
         propName="IndicatorLED"
@@ -482,7 +491,11 @@ class RfSystemsOperations():
         else: return(rc,r,False,None)
 
 
-    def setBootOverride(self,sc,op,rft,cmdTop=False, prop=None):
+    def setIndicatorLed(self, sc, op, rft, cmdTop=False, prop=None):
+        return op.iterate_op(op.setIndicatorLed_single, sc, op, rft, cmdTop=cmdTop, prop=prop)
+
+
+    def setBootOverride_single(self,sc,op,rft,cmdTop=False, prop=None):
         # this operation has argument syntaxes below:
         #     ...setBootOverride <enabledVal> [<targetVal>]
         #       where <targetVal> is not required if enabledVal==Disabled
@@ -575,6 +588,10 @@ class RfSystemsOperations():
             return(rc,r,j,bootd)
         
         else: return(rc,r,False,None)
+
+
+    def setBootOverride(self, sc, op, rft, cmdTop=False, prop=None):
+        return op.iterate_op(op.setBootOverride_single, sc, op, rft, cmdTop=cmdTop, prop=prop)
 
 
     def getProcessors(self,sc,op, rft, cmdTop=False, prop=None):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='redfishtool',
-      version='1.0.1',
+      version='1.0.2',
       description='Redfishtool package and command-line client',
       author='DMTF, https://www.dmtf.org/standards/feedback',
       license='BSD 3-clause "New" or "Revised License"',
@@ -14,7 +14,7 @@ setup(name='redfishtool',
       ],
       keywords='Redfish',
       url='https://github.com/DMTF/Redfishtool',
-      download_url='https://github.com/DMTF/Redfishtool/archive/1.0.1.tar.gz',
+      download_url='https://github.com/DMTF/Redfishtool/archive/1.0.2.tar.gz',
       packages=['redfishtool'],
       scripts=['scripts/redfishtool'],
       install_requires=['requests']


### PR DESCRIPTION
Using the `--all` option with Systems commands will perform the command on all systems in Systems collection. The commands updated are:
- reset
- patch
- setAssetTag
- setIndicatorLed
- setBootOverride

Similarly, the `--all` option with Chassis commands will perform the command on all chassis in Chassis collection. The commands updated are:
- patch
- setAssetTag
- setIndicatorLed
- setPowerLimit

Fixes #22 