### PR TITLE
Add '--Entries' option to get log entries for Systems, Chassis and Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ While other generic http clients such as Linux curl can send and receive Redfish
        -c <cfgFile>,--config=<cfgFile>  -- read options (including credentials) from file <cfgFile>
        -T <timeout>,--Timeout=<timeout> -- timeout in seconds for each http request.  Default=10
        -P <property>, --Prop=<property> -- return only the specified property. Applies only to all "get" operations
+       -E, --Entries                    -- Fetch the Logs entries. Applies to Logs sub-command of Systems, Chassis and Managers
        -v,  --verbose                   -- verbose level, can repeat up to 5 times for more verbose output
                                            -v(header), -vv(+addl info), -vvv(Request trace), -vvvv(+subCmd dbg), 
                                            -vvvvv(max dbg)
@@ -139,18 +140,19 @@ While other generic http clients such as Linux curl can send and receive Redfish
       setAssetTag <assetTag>    -- set the system's asset tag
       setIndicatorLed  <state>  -- set the indicator LED.  <state>=redfish defined values: Off, Lit, Blinking
       setBootOverride <enabledVal> <targetVal> -- set Boot Override properties. <enabledVal>=Disabled|Once|Continuous
-                               -- <targetVal> =None|Pxe|Floppy|Cd|Usb|Hdd|BiosSetup|Utilities|Diags|UefiTarget|
+                                -- <targetVal> =None|Pxe|Floppy|Cd|Usb|Hdd|BiosSetup|Utilities|Diags|UefiTarget|
       Processors [list]         -- get the "Processors" collection, or list "id" and URI of members.
-       Processors [IDOPTN]        --  get the  member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+       Processors [IDOPTN]      -- get the  member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
 
       EthernetInterfaces [list] -- get the "EthernetInterfaces" collection, or list "id" and URI of members.
-       EthernetInterfaces [IDOPTN]--  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+       EthernetInterfaces [IDOPTN] -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
 
       SimpleStorage [list]      -- get the ComputerSystem "SimpleStorage" collection, or list "id" and URI of members.
-       SimpleStorage [IDOPTN]     --  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+       SimpleStorage [IDOPTN]   -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
 
       Logs [list]               -- get the ComputerSystem "LogServices" collection , or list "id" and URI of members.
-       Logs [IDOPTN]              --  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+       Logs [IDOPTN]            -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+       Logs -E [IDOPTN]         -- get the log entries specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
       clearLog   <id>           -- clears the log defined by <id>
       examples                  -- example commands with syntax
       hello                     -- Systems hello -- debug command
@@ -176,7 +178,8 @@ While other generic http clients such as Linux curl can send and receive Redfish
                      <limit>=null disables power limiting. <indx> is the powerControl array indx (dflt=0)
     
         Logs [list]                   -- get the Chassis "LogServices" collection , or list "id" and URI of members.
-          Logs [IDOPTN]                -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+          Logs [IDOPTN]               -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+          Logs -E [IDOPTN]            -- get the log entries specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
         clearLog   <id>               -- clears the log defined by <id>
         examples                      -- example commands with syntax
         hello                         -- Chassis hello -- debug command
@@ -192,19 +195,20 @@ While other generic http clients such as Linux curl can send and receive Redfish
      patch {A: B,C: D,...}        -- patch the json-formated {prop: value...} data to the object
      reset <resetType>            -- reset a Manager.  <resetType>= On,  GracefulShutdown, GracefulRestart,
                                       ForceRestart, ForceOff, ForceOn, Nmi, PushPowerPutton
-     setDateTime <dateTimeString> --set the date and time
-     setTimeOffset <offsetSTring> --set the time offset w/o changing time setting
+     setDateTime <dateTimeString> -- set the date and time
+     setTimeOffset <offsetSTring> -- set the time offset w/o changing time setting
      NetworkProtocol              -- get the "NetworkProtocol" resource under the specified manager.
      setIpAddress [-i<indx>]...   -- set the Manager IP address -NOT IMPLEMENTED YET
 
      EthernetInterfaces [list]    -- get the managers "EthernetInterfaces" collection, or list "id",URI, Name of members
-      EthernetInterfaces [IDOPTN]   --  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -a #all
+      EthernetInterfaces [IDOPTN] -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -a #all
 
      SerialInterfaces [list]      -- get the managers "SerialInterfaces" collection, or list "id",URI, Name of members.
-      SerialInterfaces [IDOPTN]     --  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+      SerialInterfaces [IDOPTN]   -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
 
      Logs [list]                  -- get the Managers "LogServices" collection , or list "id",URI, Name of members.
-      Logs [IDOPTN]                 --  get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+      Logs [IDOPTN]               -- get the member specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
+      Logs -E [IDOPTN]            -- get the log entries specified by IDOPTN: -i<id>, -m<prop>:<val>, -l<link>, -a #all
      clearLog   <id>              -- clears the log defined by <id>
      examples                     -- example commands with syntax
      hello                        -- Systems hello -- debug command
@@ -348,6 +352,12 @@ While other generic http clients such as Linux curl can send and receive Redfish
      # Gets processor with property Socket=CPU_1, on system at url <sysUrl>
      redfishtool -r <ip> -u <username> -p <password> Systems -L <sysUrl> Processors -m Socket:CPU_1
 
+     # Gets log member with Id=SEL from the first System
+     redfishtool -r <ip> -u <username> -p <password> Systems -1 Logs -i SEL
+
+     # Gets log entries with Id=SEL from the first System
+     redfishtool -r <ip> -u <username> -p <password> Systems -1 Logs -E -i SEL
+
 ### Chassis subcommand Examples
 
     $ python redfishtool.py -r <ip> -u <username> -p <password> Chassis examples
@@ -405,6 +415,12 @@ While other generic http clients such as Linux curl can send and receive Redfish
      # Sets the power limit on all chassis
      redfishtool -r <ip> -u <username> -p <password> Chassis --all setPowerLimit [-i<indx>] <limit> [<exception> [<correctionTime>]]
 
+     # Gets log member with Id=SEL from the first Chassis
+     redfishtool -r <ip> -u <username> -p <password> Chassis -1 Logs -i SEL
+
+     # Gets log entries with Id=SEL from the first Chassis
+     redfishtool -r <ip> -u <username> -p <password> Chassis -1 Logs -E -i SEL
+
 ### Managers subcommand Examples
 
     $ python redfishtool.py -r <ip> -u <username> -p <password> Managers examples
@@ -445,7 +461,13 @@ While other generic http clients such as Linux curl can send and receive Redfish
      redfishtool -r <ip> -u <username> -p <password> Managers -I <Id> EthernetInterfaces -i 1
 
      # Gets the NIC with MAC AA:BB:CC:DD:EE:FF for manager at url <Url>
-     redfishtool -r <ip> -u <username> -p <password> Managers -L <Url> EthernetInterfaces -m MACAddress:AA:BB:CC:DD:EE:FF 
+     redfishtool -r <ip> -u <username> -p <password> Managers -L <Url> EthernetInterfaces -m MACAddress:AA:BB:CC:DD:EE:FF
+
+     # Gets log member with Id=SEL from the first Manager
+     redfishtool -r <ip> -u <username> -p <password> Managers -1 Logs -i SEL
+
+     # Gets log entries with Id=SEL from the first Manager
+     redfishtool -r <ip> -u <username> -p <password> Managers -1 Logs -E -i SEL
 
 ### AccountService subcommand Examples
 

--- a/redfishtool/Chassis.py
+++ b/redfishtool/Chassis.py
@@ -714,6 +714,25 @@ class RfChassisOperations():
                 if(rc==0):
                     rft.printVerbose(1," {} Collection Member ".format(collName,skip1=True, printV12=cmdTop))
 
+            # If '--Entries' specified, get "Entries" nav link and read it
+            if rc == 0 and rft.gotEntriesOptn:
+                if r is not None and j and isinstance(d, dict):
+                    rft.printVerbose(1, 'getLogService: attempting to get Entries for Logs')
+                    entries = d.get('Entries')
+                    if entries is not None and isinstance(entries, dict):
+                        entries_uri = entries.get('@odata.id')
+                        if entries_uri is not None:
+                            rc, r, j, d = rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url,
+                                                                 relPath=entries_uri, prop=prop)
+                        else:
+                            rft.printErr('getLogService: @odata.id not found in "Entries" property')
+                    else:
+                        rft.printErr('getLogService: "Entries" property not found in JSON payload')
+                else:
+                    rft.printErr(
+                        'Unable to fetch Entries property from previous response: response = {}, is_json = {}, type(json) = {}'
+                        .format(r, j, type(d)))
+
         # else, client specified the -a option requesting ALL of the LogServices members
         # for logs, we will not support this.  Its too much data.
         else:

--- a/redfishtool/Managers.py
+++ b/redfishtool/Managers.py
@@ -662,6 +662,25 @@ class RfManagersOperations():
                 if(rc==0):
                     rft.printVerbose(1," {} Collection Member ".format(collName,skip1=True, printV12=cmdTop))
 
+            # If '--Entries' specified, get "Entries" nav link and read it
+            if rc == 0 and rft.gotEntriesOptn:
+                if r is not None and j and isinstance(d, dict):
+                    rft.printVerbose(1, 'getLogService: attempting to get Entries for Logs')
+                    entries = d.get('Entries')
+                    if entries is not None and isinstance(entries, dict):
+                        entries_uri = entries.get('@odata.id')
+                        if entries_uri is not None:
+                            rc, r, j, d = rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url,
+                                                                 relPath=entries_uri, prop=prop)
+                        else:
+                            rft.printErr('getLogService: @odata.id not found in "Entries" property')
+                    else:
+                        rft.printErr('getLogService: "Entries" property not found in JSON payload')
+                else:
+                    rft.printErr(
+                        'Unable to fetch Entries property from previous response: response = {}, is_json = {}, type(json) = {}'
+                        .format(r, j, type(d)))
+
         # else, client specified the -a option requesting ALL of the LogServices members
         # for logs, we will not support this.  Its too much data.
         else:

--- a/redfishtool/Systems.py
+++ b/redfishtool/Systems.py
@@ -848,6 +848,25 @@ class RfSystemsOperations():
                 if(rc==0):
                     rft.printVerbose(1," {} Collection Member ".format(collName,skip1=True, printV12=cmdTop))
 
+            # If '--Entries' specified, get "Entries" nav link and read it
+            if rc == 0 and rft.gotEntriesOptn:
+                if r is not None and j and isinstance(d, dict):
+                    rft.printVerbose(1, 'getLogService: attempting to get Entries for Logs')
+                    entries = d.get('Entries')
+                    if entries is not None and isinstance(entries, dict):
+                        entries_uri = entries.get('@odata.id')
+                        if entries_uri is not None:
+                            rc, r, j, d = rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url,
+                                                                 relPath=entries_uri, prop=prop)
+                        else:
+                            rft.printErr('getLogService: @odata.id not found in "Entries" property')
+                    else:
+                        rft.printErr('getLogService: "Entries" property not found in JSON payload')
+                else:
+                    rft.printErr(
+                        'Unable to fetch Entries property from previous response: response = {}, is_json = {}, type(json) = {}'
+                        .format(r, j, type(d)))
+
         # else, client specified the -a option requesting ALL of the LogServices members
         # for logs, we will not support this.  Its too much data.
         else:

--- a/redfishtool/redfishtoolMain.py
+++ b/redfishtool/redfishtoolMain.py
@@ -54,6 +54,7 @@ def displayOptions(rft):
         print("   -T <timeout>,--Timeout=<timeout> -- timeout in seconds for each http request.  Default=10")
         print("")
         print("   -P <property>, --Prop=<property> -- return only the specified property. Applies only to all \"get\" operations")
+        print("   -E, --Entries                    -- Fetch the Logs entries. Applies to Logs sub-command of Systems, Chassis and Managers")
         print("")
         print("  Options used by \"raw\" subcommand:")
         print("   -d <data>    --data=<data>       -- the http request \"data\" to send on PATCH,POST,or PUT requests")
@@ -120,10 +121,10 @@ def main(argv):
     rft=RfTransport()
 
     try:
-        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:I:M:F1L:i:m:l:aW:A:S:R:H:D:C",
+        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:EI:M:F1L:i:m:l:aW:A:S:R:H:D:C",
                         ["Version", "help", "verbose", "status", "quiet", 
                          "user=", "password=", "rhost=", "token=", "config=", "Timeout=",
-                         "Prop=", "data=", "Id=", "Match=", "First", "One", "Link=",
+                         "Prop=", "data=", "Entries", "Id=", "Match=", "First", "One", "Link=",
                          "id=", "match=", "link", "all",
                          "Wait=", "Auth=","Secure=", "RedfishVersion=", "Headers=", "Debug=",
                          "CheckRedfishVersion"  ])
@@ -171,6 +172,9 @@ def main(argv):
         # options used by raw subcommand to specify http method (-X, --request) and request data (-d, --data)
         elif opt in ("-d", "--data"):
             rft.requestData=arg
+        # options related to the Logs sub-command of Systems, Chassis and Managers
+        elif opt in ("-E", "--Entries"):
+            rft.gotEntriesOptn = True
         # options to find the Id or member of a collection in a subcommand
         elif opt in ("-I", "--Id"):
             rft.Id=arg
@@ -340,8 +344,8 @@ def main(argv):
                                                         rft.protocolVer, rft.auth, rft.timeout))
     rft.printVerbose(5,"Main: prop={}, Id={}, Match={}:{}, First={}, -1={}, Link={}".format( rft.prop,
                         rft.Id, rft.matchProp,rft.matchValue, rft.firstOptn, rft.oneOptn, rft.Link))
-    rft.printVerbose(5,"Main: gotIdOptn={}, IdOptnCount={}, gotPropOptn={}, gotMatchOptn={}".format(
-                            rft.gotIdOptn, rft.IdOptnCount, rft.gotPropOptn, rft.gotMatchOptn))
+    rft.printVerbose(5,"Main: gotIdOptn={}, IdOptnCount={}, gotPropOptn={}, gotMatchOptn={}, gotEntriesOptn={}".format(
+                            rft.gotIdOptn, rft.IdOptnCount, rft.gotPropOptn, rft.gotMatchOptn, rft.gotEntriesOptn))
     rft.printVerbose(5,"Main: 2nd-Level Collection Member reference options: -i<id>={}, -m<match>={}:{}, -l<link>={} -all={}".format(
                             rft.IdLevel2, rft.matchLevel2Prop, rft.matchLevel2Value, rft.linkLevel2, rft.allOptn))
     rft.printVerbose(5,"Main: 2nd-level Collection Member parsing: gotIdLevel2Optn={}, gotMatchLevel2Optn={}, IdLevel2OptnCount={}".format(

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -103,6 +103,7 @@ class RfTransport():
         self.gotMatchOptn=False
         self.matchProp=None
         self.matchValue=None
+        self.gotEntriesOptn = False
         
         self.IdLevel2=None
         self.gotIdLevel2Optn=False


### PR DESCRIPTION
The existing behavior of the 'Logs' sub-command for Systems, Chassis and Managers just gets the LogService member. Added a `--Entries` option to get the log entries instead.

Original behavior:

```
$ python3 redfishtool.py -r 127.0.0.1:8004 -S Never Systems -1 Logs -i SEL 
{
    "Id": "SEL",
    "Entries": {
        "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries"
    },
    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL",
    "Status": {
        "Health": "OK",
        "State": "Enabled"
    },
    "ServiceEnabled": true,
    "MaxNumberOfRecords": 1000,
    "OverWritePolicy": "WrapsWhenFull",
    "DateTime": "2015-03-13T04:14:33+06:00",
    "DateTimeLocalOffset": "+06:00",
    "Oem": {},
    "Name": "System Log Service",
    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
    "Actions": {
        "Oem": {},
        "#LogService.ClearLog": {
            "target": "/redfish/v1/Systems/1/LogServices/SEL/Actions/LogService.Reset"
        }
    },
    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright.",
    "@odata.type": "#LogService.v1_0_2.LogService"
}
```

With new --Entries (or -E) option:

```
$ python3 redfishtool.py -r 127.0.0.1:8004 -S Never Systems -1 Logs --Entries -i SEL
{
    "@odata.type": "#LogEntryCollection.LogEntryCollection",
    "Description": "Collection of Logs for this System",
    "@odata.context": "/redfish/v1/$metadata#LogEntryCollection.LogEntryCollection",
    "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries",
    "Members@odata.count": 2,
    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright.",
    "Members": [
        {
            "Links": {
                "OriginOfCondition": {
                    "@odata.id": "/redfish/v1/Chassis/1/Thermal"
                },
                "Oem": {}
            },
            "Message": "Message for Event, Description for SEL, OEM depends",
            "EntryType": "SEL",
            "Oem": {},
            "Name": "Log Entry 1",
            "MessageArgs": [
                "ArrayOfMessageArgs"
            ],
            "EntryCode": "Assert",
            "SensorType": "Temperature",
            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
            "OemRecordFormat": "CompanyX",
            "RecordId": 1,
            "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/1",
            "Id": "1",
            "Severity": "Critical",
            "Number": 1,
            "Created": "2012-03-07T14:44",
            "MessageId": "Event.1.0.TempAssert"
        },
        {
            "OEMRecordFormat": "CompanyX",
            "Links": {
                "OriginOfCondition": {
                    "@odata.id": "/redfish/v1/Chassis/1/Thermal"
                },
                "Oem": {}
            },
            "Message": "Message for Event, Description for SEL, OEM depends",
            "EntryType": "SEL",
            "Oem": {},
            "MessageArgs": [
                "ArrayOfMessageArgs"
            ],
            "Name": "Log Entry 2",
            "SensorType": "Temperature",
            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
            "EntryCode": "Assert",
            "RecordId": 2,
            "@odata.id": "/redfish/v1/Systems/1/LogServices/SEL/Entries/2",
            "Id": "2",
            "Severity": "Critical",
            "Number": 2,
            "Created": "2012-03-07T14:45",
            "MessageId": "Event.1.0.TempAssert"
        }
    ],
    "Name": "Log Service Collection",
    "@odata.nextLink": "/redfish/v1/Systems/1/LogServices/SEL/Entries?$skiptoken=2"
}
```

Fixes #9 