### PR TITLE
 Make --One default top-level member selection option

### DIFF
--- a/redfishtool/Chassis.py
+++ b/redfishtool/Chassis.py
@@ -147,8 +147,7 @@ class RfChassisMain():
         rft.printVerbose(5,"Chassis: operation={}, args={}".format(self.operation,self.args))
                 
         # check if the command requires a collection member target -I|-M|-L|-1|-F eg sysIdoptn
-        nonIdCommands=["collection", "list", "examples", "hello", "patch", "setAssetTag",
-                       "setIndicatorLed", "setPowerLimit"]
+        nonIdCommands = ["collection", "list", "examples", "hello"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
             # default to --One if no Id option specified
             rft.oneOptn = True

--- a/redfishtool/Chassis.py
+++ b/redfishtool/Chassis.py
@@ -150,8 +150,9 @@ class RfChassisMain():
         nonIdCommands=["collection", "list", "examples", "hello", "patch", "setAssetTag",
                        "setIndicatorLed", "setPowerLimit"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
-            rft.printErr("Chassis: Syntax error: [-I|-M|-L|-F|-1] required for action that targets a specific Chassis instance")
-            return(0,None,False,None)
+            # default to --One if no Id option specified
+            rft.oneOptn = True
+            rft.IdOptnCount += 1
             
         # now execute the operation.
         rc,r,j,d = self.runOperation(rft)

--- a/redfishtool/Managers.py
+++ b/redfishtool/Managers.py
@@ -152,8 +152,9 @@ class RfManagersMain():
         # check if the command requires a collection member target -I|-M|-L|-1|-F eg sysIdoptn
         nonIdCommands=["collection", "list", "examples", "hello"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
-            rft.printErr("Managers: Syntax error: [-I|-M|-L|-F|-1] required for action that targets a specific Managers instance")
-            return(0,None,False,None)
+            # default to --One if no Id option specified
+            rft.oneOptn = True
+            rft.IdOptnCount += 1
             
         # now execute the operation.
         rc,r,j,d = self.runOperation(rft)

--- a/redfishtool/Systems.py
+++ b/redfishtool/Systems.py
@@ -157,8 +157,9 @@ class RfSystemsMain():
         nonIdCommands=["collection", "list", "examples", "hello", "reset", "patch", "setAssetTag",
                        "setIndicatorLed", "setBootOverride"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
-            rft.printErr("Systems: Syntax error: [-I|-M|-L|-F|-1] required for action that targets a specific system instance")
-            return(0,None,False,None)
+            # default to --One if no Id option specified
+            rft.oneOptn = True
+            rft.IdOptnCount += 1
             
         # now execute the operation.
         rc,r,j,d = self.runOperation(rft)

--- a/redfishtool/Systems.py
+++ b/redfishtool/Systems.py
@@ -154,8 +154,7 @@ class RfSystemsMain():
         rft.printVerbose(5,"Systems: operation={}, args={}".format(self.operation,self.args))
                 
         # check if the command requires a collection member target -I|-M|-L|-1|-F eg sysIdoptn
-        nonIdCommands=["collection", "list", "examples", "hello", "reset", "patch", "setAssetTag",
-                       "setIndicatorLed", "setBootOverride"]
+        nonIdCommands = ["collection", "list", "examples", "hello"]
         if( ( not self.operation in nonIdCommands ) and (rft.IdOptnCount==0) ):
             # default to --One if no Id option specified
             rft.oneOptn = True

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -883,7 +883,12 @@ class RfTransport():
 
         elif(rft.oneOptn):
             if(numOfLinks > 1):
-                rft.printErr("Error: getPathBy --One option: more than one link in members array")
+                rc, r, j, d = rft.listCollection(rft, r, coll, prop=None)
+                id_list = []
+                if not rc and 'Members' in d:
+                    id_list = [m['Id'] for m in d['Members'] if 'Id' in m]
+                rft.printErr("Error: No target specified, but multiple IDs found: {}. Re-issue command with '-I <Id>' to select target."
+                             .format(repr(id_list)))
                 return(None,1,None,False,None)
             if('@odata.id'  not in coll['Members'][0] ):
                 rft.printErr("Error: getPathBy --One option: improper formatted link-no @odata.id")

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -887,8 +887,9 @@ class RfTransport():
                 id_list = []
                 if not rc and 'Members' in d:
                     id_list = [m['Id'] for m in d['Members'] if 'Id' in m]
-                rft.printErr("Error: No target specified, but multiple IDs found: {}. Re-issue command with '-I <Id>' to select target."
-                             .format(repr(id_list)))
+                rft.printErr("Error: No target specified, but multiple {} IDs found: {}"
+                             .format(rft.subcommand, repr(id_list)))
+                rft.printErr("Re-issue command with '-I <Id>' to select target.")
                 return(None,1,None,False,None)
             if('@odata.id'  not in coll['Members'][0] ):
                 rft.printErr("Error: getPathBy --One option: improper formatted link-no @odata.id")


### PR DESCRIPTION
Per issue #59, updated code to make the `--One` option for default for `Systems`, `Managers` and `Chassis` commands that normally require a top-level member selection option. In this scenario, if there is more than one member in the collection, issue a more helpful message that lists the member IDs and suggests to re-run the command and select the target with the `-I <Id>` option. For example:

```
$ python3 redfishtool.py -r 127.0.0.1:8006 -S Never Chassis setAssetTag "ABCD"
   redfishtool: Error: No target specified, but multiple Chassis IDs found: ['MultiBladeEncl', 'Blade1', 'Blade2', 'Blade3', 'Blade4']
   redfishtool: Re-issue command with '-I <Id>' to select target.
```

During testing, I found there was a legacy bug in the `Chassis` and `Systems` modules with the list of commands that do not require specifying an Id option. This was fixed as well.

Fixes #59 
