### PR TITLE
Enhance get power/thermal data function.

### DIFF
--- a/redfishtool/Chassis.py
+++ b/redfishtool/Chassis.py
@@ -231,7 +231,7 @@ class RfChassisOperations():
         collUrl=r.url
 
         # search collection to find path to system
-        sysPath,rc,r,j,d=rft.getPathBy(rft, r, d)
+        sysPath,rc,r,j,d=rft.getPathBy(rft, r, d, prop)
         if( rc !=0 ):    #if a path was not found, its an error
             return(rc,r,j,d)
         
@@ -422,12 +422,12 @@ class RfChassisOperations():
 
     def getPower(self,sc,op, rft, cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in operation".format(rft.subcommand,sc.operation))
+        resName="Power"
 
         # get the Chassis resource first
-        rc,r,j,d=op.get(sc,op, rft)     
+        rc,r,j,d=op.get(sc, op, rft, cmdTop, resName)
         if( rc != 0):  return(rc,r,False,None)
         
-        resName="Power"
         # get the link to the Power resource under Chassis
         if ((resName in d) and ("@odata.id" in d[resName])):
             resLink=d[resName]["@odata.id"]
@@ -447,12 +447,11 @@ class RfChassisOperations():
 
     def getThermal(self,sc,op,rft,cmdTop=False, prop=None):
         rft.printVerbose(4,"{}:{}: in operation".format(rft.subcommand,sc.operation))
-
+        resName="Thermal"
         # get the Chassis resource first
-        rc,r,j,d=op.get(sc,op, rft)     
+        rc,r,j,d=op.get(sc, op, rft, cmdTop, resName)
         if( rc != 0):  return(rc,r,False,None)
         
-        resName="Thermal"
         # get the link to the Thermal resource under Chassis
         if ((resName in d) and ("@odata.id" in d[resName])):
             resLink=d[resName]["@odata.id"]

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -857,7 +857,7 @@ class RfTransport():
 
 
 
-    def getPathBy(self,rft, r, coll):
+    def getPathBy(self,rft, r, coll, prop=None):
         if('Members'  not in coll):
             rft.printErr("Error: getPathBy: no members array in collection")
             return(None,1,None,False,None)
@@ -883,10 +883,15 @@ class RfTransport():
 
         elif(rft.oneOptn):
             if(numOfLinks > 1):
-                rc, r, j, d = rft.listCollection(rft, r, coll, prop=None)
+                rc, r, j, d = rft.listCollection(rft, r, coll, prop)
                 id_list = []
+
                 if not rc and 'Members' in d:
-                    id_list = [m['Id'] for m in d['Members'] if 'Id' in m]
+                    if prop is not None:
+                        if d['Members'] and '@odata.id' in d['Members'][0]:
+                            return(d['Members'][0]['@odata.id'],0,None,False,None)
+                    else:
+                        id_list = [m['Id'] for m in d['Members'] if 'Id' in m]
                 rft.printErr("Error: No target specified, but multiple {} IDs found: {}"
                              .format(rft.subcommand, repr(id_list)))
                 rft.printErr("Re-issue command with '-I <Id>' to select target.")
@@ -1034,7 +1039,8 @@ class RfTransport():
                     if( prop is not None ):
                         listMember[prop]=propVal           
                     # add the member to the listd
-                    members.append(listMember)
+                    if (prop is None) or (propVal is not None):
+                        members.append(listMember)
 
         #create base list dictionary
         collPath=urlparse(baseUrl).path


### PR DESCRIPTION
For different type of servers, we may get more than 1 chassis items.
Eg. In wolfpass server, there are many subitems in Chassis item.
If we use Chassis Power command, it will report error and request
client to specify one subitem by -I, and retry one by one to find
the item which includes power data.

In this patch, it utilize existed prop paramete and can report the
subitem which includes power during it go through all chassis
subitems, so that client can get Power data by one Chassis Power
command directly.

Signed-off-by: zhipengl <zhipengs.liu@intel.com>