### PR TITLE
Properly populate url to accept IPv6 addresses

### DIFF
--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -39,6 +39,7 @@ import json
 import sys
 import socket
 import time
+import ipaddress
 from urllib.parse import urljoin, urlparse, urlunparse
 from requests.auth import HTTPBasicAuth, AuthBase
 from .ServiceRoot import RfServiceRoot
@@ -212,7 +213,15 @@ class RfTransport():
 
             # calculate the rootUri including scheme,rhost,rootPath properly
             scheme=rft.getApiScheme(rft.UNAUTHENTICATED_API)
-            scheme_tuple=[scheme,rft.rhost, rft.rootPath, "","",""]
+
+            rhost = rft.rhost
+            try:
+                if ipaddress.ip_address(rhost).version == 6:
+                    rhost = '[{}]'.format(rhost)
+            except ValueError:
+                pass
+
+            scheme_tuple=[scheme, rhost, rft.rootPath, "","",""]
             rootUrl=urlunparse(scheme_tuple)
             rft.rootUri=rootUrl
             # save parameters


### PR DESCRIPTION
URLs with IPv6 addresses in them should use [ ] around the address

This then works:

$ redfishtool -r 2001:db8:100::482 -u ADMIN -p ADMIN Systems reset ForceOn

Debugging will show this URL is generated:

  Transport.ProcessRequest: url=http://[2001:db8:100::482]/redfish/v1/

Signed-off-by: Wido den Hollander <wido@widodh.nl>