### PR TITLE
Show collection members even if optional prop not present

### DIFF
--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -1045,11 +1045,10 @@ class RfTransport():
                     # create a member dict. Always include  Id and path
                     listMember={"Id": d["Id"], "@odata.id": d["@odata.id"] }
                     # if a property was specified to include, add it to the list dict
-                    if( prop is not None ):
+                    if( prop in d ):
                         listMember[prop]=propVal           
-                    # add the member to the listd
-                    if (prop is None) or (propVal is not None):
-                        members.append(listMember)
+                    # add the member to the list
+                    members.append(listMember)
 
         #create base list dictionary
         collPath=urlparse(baseUrl).path


### PR DESCRIPTION
For some reason, in `listCollection()`, the collection members are not added to the returned member list if the specified prop (e.g. AssetTag) is not present in the member resource.

Fixed the code so that all the members are displayed. If the prop is present, it is shown in the output.

**Before fix:**

AssetTag present:

```
{
    "_Path": "/redfish/v1/Systems",
    "Name": "Computer System Collection",
    "Members@odata.count": 1,
    "Members": [
        {
            "Id": "437XR1138R2",
            "@odata.id": "/redfish/v1/Systems/437XR1138R2",
            "AssetTag": "Chicago-45Z-2381"
        }
    ]
}
```

AssetTag not present:

```
{
    "_Path": "/redfish/v1/Systems",
    "Name": "Computer System Collection",
    "Members@odata.count": 1,
    "Members": []
}
```
**After fix:**

AssetTag present:

```
{
    "_Path": "/redfish/v1/Systems",
    "Name": "Computer System Collection",
    "Members@odata.count": 1,
    "Members": [
        {
            "Id": "437XR1138R2",
            "@odata.id": "/redfish/v1/Systems/437XR1138R2",
            "AssetTag": "Chicago-45Z-2381"
        }
    ]
}
```

AssetTag not present:

```
{
    "_Path": "/redfish/v1/Systems",
    "Name": "Computer System Collection",
    "Members@odata.count": 1,
    "Members": [
        {
            "Id": "437XR1138R2",
            "@odata.id": "/redfish/v1/Systems/437XR1138R2"
        }
    ]
}
```

Fixes #76 