### PR TITLE
Make async tasks blocking by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For `Systems`, `Managers`, and `Chassis` commands that require specifying a top-
     -C         --CheckRedfishVersion -- tells Redfishtool to execute GET /redfish to verify that the rhost supports
                                         the specified redfish protocol version before executing a sub-command. 
                                         The -C flag is auto-set if the -R Latest or -W ... options are selected
-    -B,        --Blocking            -- Wait for asynchronous requests to complete.
+    -N,        --NonBlocking         -- Do not wait for asynchronous requests to complete.
     -H <hdrs>, --Headers=<hdrs>      -- Specify the request header list--overrides defaults. Format "{ A:B, C:D...}" 
     -D <flag>,  --Debug=<flag>       -- Flag for dev debug. <flag> is a 32-bit uint: 0x<hex> or <dec> format
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ pip install redfishtool
 ***redfishtool*** is based on Python 3 and the client system is required to have the Python framework installed before the tool can be installed and executed on the system.
 
 If cloning the tool from Github, as opposed to performing the installation via pip, the following packages are required to be installed and accessible from the python environment:
-* requests - https://github.com/kennethreitz/requests
+
+* requests - [https://github.com/psf/requests]()
+* python-dateutil - [https://github.com/dateutil/dateutil]()
 
 You may install the required packages by running:
 
@@ -127,6 +129,7 @@ For `Systems`, `Managers`, and `Chassis` commands that require specifying a top-
     -C         --CheckRedfishVersion -- tells Redfishtool to execute GET /redfish to verify that the rhost supports
                                         the specified redfish protocol version before executing a sub-command. 
                                         The -C flag is auto-set if the -R Latest or -W ... options are selected
+    -B,        --Blocking            -- Wait for asynchronous requests to complete.
     -H <hdrs>, --Headers=<hdrs>      -- Specify the request header list--overrides defaults. Format "{ A:B, C:D...}" 
     -D <flag>,  --Debug=<flag>       -- Flag for dev debug. <flag> is a 32-bit uint: 0x<hex> or <dec> format
 

--- a/redfishtool/redfishtoolMain.py
+++ b/redfishtool/redfishtoolMain.py
@@ -85,6 +85,7 @@ def displayOptions(rft):
         print("   -C         --CheckRedfishVersion -- tells Redfishtool to execute GET /redfish to verify that the rhost supports")
         print("                                       the specified redfish protocol version before executing a sub-command. ")
         print("                                       The -C flag is auto-set if the -R Latest or -W ... options are selected")
+        print("   -B,        --Blocking            -- Wait for asynchronous requests to complete.")
         print("   -H <hdrs>, --Headers=<hdrs>      -- Specify the request header list--overrides defaults. Format \"{ A:B, C:D...}\" ")
         print("   -D <flag>,  --Debug=<flag>       -- Flag for dev debug. <flag> is a 32-bit uint: 0x<hex> or <dec> format")
         print("")
@@ -121,13 +122,13 @@ def main(argv):
     rft=RfTransport()
 
     try:
-        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:EI:M:F1L:i:m:l:aW:A:S:R:H:D:C",
+        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:EI:M:F1L:i:m:l:aW:A:S:R:H:D:CB",
                         ["Version", "help", "verbose", "status", "quiet", 
                          "user=", "password=", "rhost=", "token=", "config=", "Timeout=",
                          "Prop=", "data=", "Entries", "Id=", "Match=", "First", "One", "Link=",
                          "id=", "match=", "link", "all",
                          "Wait=", "Auth=","Secure=", "RedfishVersion=", "Headers=", "Debug=",
-                         "CheckRedfishVersion"  ])
+                         "CheckRedfishVersion", "Blocking"])
     except getopt.GetoptError:
         rft.printErr("Error parsing options")
         displayUsage(rft)
@@ -284,6 +285,8 @@ def main(argv):
                 sys.exit(1)
         elif opt in ("-C", "--CheckRedfishVersion"):
             rft.checkProtocolVer=True
+        elif opt in ("-B", "--Blocking"):
+            rft.blocking=True
         else:
             rft.printErr("Error: Unsupported option: {}".format(opt))
             displayUsage(rft)
@@ -350,8 +353,8 @@ def main(argv):
     rft.printVerbose(5,"Main: subcmd: {}, subCmdArgs:{}".format(rft.subcommand,rft.subcommandArgv))
     rft.printVerbose(5,"Main: verbose={}, status={}, user={}, password={}, rhost={}".format(rft.verbose, rft.status,
                                                         rft.user,rft.password,rft.rhost))
-    rft.printVerbose(5,"Main: token={}, RedfishVersion={}, Auth={}, Timeout={}".format(rft.token,
-                                                        rft.protocolVer, rft.auth, rft.timeout))
+    rft.printVerbose(5,"Main: token={}, RedfishVersion={}, Auth={}, Timeout={}, Blocking={}".format(rft.token,
+                                                        rft.protocolVer, rft.auth, rft.timeout, rft.blocking))
     rft.printVerbose(5,"Main: prop={}, Id={}, Match={}:{}, First={}, -1={}, Link={}".format( rft.prop,
                         rft.Id, rft.matchProp,rft.matchValue, rft.firstOptn, rft.oneOptn, rft.Link))
     rft.printVerbose(5,"Main: gotIdOptn={}, IdOptnCount={}, gotPropOptn={}, gotMatchOptn={}, gotEntriesOptn={}".format(

--- a/redfishtool/redfishtoolMain.py
+++ b/redfishtool/redfishtoolMain.py
@@ -85,7 +85,7 @@ def displayOptions(rft):
         print("   -C         --CheckRedfishVersion -- tells Redfishtool to execute GET /redfish to verify that the rhost supports")
         print("                                       the specified redfish protocol version before executing a sub-command. ")
         print("                                       The -C flag is auto-set if the -R Latest or -W ... options are selected")
-        print("   -B,        --Blocking            -- Wait for asynchronous requests to complete.")
+        print("   -N,        --NonBlocking         -- Do not wait for asynchronous requests to complete.")
         print("   -H <hdrs>, --Headers=<hdrs>      -- Specify the request header list--overrides defaults. Format \"{ A:B, C:D...}\" ")
         print("   -D <flag>,  --Debug=<flag>       -- Flag for dev debug. <flag> is a 32-bit uint: 0x<hex> or <dec> format")
         print("")
@@ -122,13 +122,13 @@ def main(argv):
     rft=RfTransport()
 
     try:
-        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:EI:M:F1L:i:m:l:aW:A:S:R:H:D:CB",
+        opts, args = getopt.gnu_getopt(argv[1:],"Vhvsqu:p:r:t:c:T:P:d:EI:M:F1L:i:m:l:aW:A:S:R:H:D:CN",
                         ["Version", "help", "verbose", "status", "quiet", 
                          "user=", "password=", "rhost=", "token=", "config=", "Timeout=",
                          "Prop=", "data=", "Entries", "Id=", "Match=", "First", "One", "Link=",
                          "id=", "match=", "link", "all",
                          "Wait=", "Auth=","Secure=", "RedfishVersion=", "Headers=", "Debug=",
-                         "CheckRedfishVersion", "Blocking"])
+                         "CheckRedfishVersion", "NonBlocking"])
     except getopt.GetoptError:
         rft.printErr("Error parsing options")
         displayUsage(rft)
@@ -285,8 +285,8 @@ def main(argv):
                 sys.exit(1)
         elif opt in ("-C", "--CheckRedfishVersion"):
             rft.checkProtocolVer=True
-        elif opt in ("-B", "--Blocking"):
-            rft.blocking=True
+        elif opt in ("-N", "--NonBlocking"):
+            rft.blocking=False
         else:
             rft.printErr("Error: Unsupported option: {}".format(opt))
             displayUsage(rft)
@@ -353,8 +353,8 @@ def main(argv):
     rft.printVerbose(5,"Main: subcmd: {}, subCmdArgs:{}".format(rft.subcommand,rft.subcommandArgv))
     rft.printVerbose(5,"Main: verbose={}, status={}, user={}, password={}, rhost={}".format(rft.verbose, rft.status,
                                                         rft.user,rft.password,rft.rhost))
-    rft.printVerbose(5,"Main: token={}, RedfishVersion={}, Auth={}, Timeout={}, Blocking={}".format(rft.token,
-                                                        rft.protocolVer, rft.auth, rft.timeout, rft.blocking))
+    rft.printVerbose(5,"Main: token={}, RedfishVersion={}, Auth={}, Timeout={}, NonBlocking={}".format(rft.token,
+                                                        rft.protocolVer, rft.auth, rft.timeout, not rft.blocking))
     rft.printVerbose(5,"Main: prop={}, Id={}, Match={}:{}, First={}, -1={}, Link={}".format( rft.prop,
                         rft.Id, rft.matchProp,rft.matchValue, rft.firstOptn, rft.oneOptn, rft.Link))
     rft.printVerbose(5,"Main: gotIdOptn={}, IdOptnCount={}, gotPropOptn={}, gotMatchOptn={}, gotEntriesOptn={}".format(

--- a/redfishtool/redfishtoolTransport.py
+++ b/redfishtool/redfishtoolTransport.py
@@ -550,9 +550,8 @@ class RfTransport():
                         return rft.waitForTask(r, urlBase2, headers=hdrs, auth=authType,
                                                verify=verify, jsonData=jsonData, **kwargs)
                     else:
-                        if not rft.blocking and r.headers.get("Location"):
-                            rft.printTaskStatus("NonBlocking: Task Monitor is %s\n" %
-                                                r.headers.get("Location"))
+                        rft.printTaskStatus("Task Monitor URL is %s\n" %
+                                            r.headers.get("Location", "<not available>"))
                         return (rc, r, False, None)
                 elif((r.status_code==200) or (r.status_code==201) ):  
                     if( jsonData is True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+python-dateutil
 requests

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(name='redfishtool',
       download_url='https://github.com/DMTF/Redfishtool/archive/1.0.5.tar.gz',
       packages=['redfishtool'],
       scripts=['scripts/redfishtool'],
-      install_requires=['requests']
+      install_requires=['python-dateutil', 'requests']
       )


### PR DESCRIPTION
Redfishtool currently treats `202 Accepted` responses from async tasks as successful and returns immediately. In most cases, the user will want the tool to wait for the async task to complete so the tool output can show the ultimate result of the task and so that subsequent tool invocations that rely on the completion of the async task can proceed.

This PR makes async tasks block by default. It also adds the additional option `--NonBlocking` (or `-N`) to indicate that the tool should NOT wait for the async task to complete.

In the blocking case, the tool displays a "Task is Running" message to STDERR (so as to not pollute the JSON output that is normally printed to STDOUT).

In the non-blocking case, the tool displays a "NonBlocking: Task Monitor is <URL>" message to STDERR.

Also note that this PR adds an additional third-party package requirement: `python-dateutil`

Fixes #77  