### PR TITLE
setup.cfg: fix SetuptoolsDeprecationWarning: Invalid dash-separated options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Resolves #118 

resolves the deprecated use of hypenated option names.